### PR TITLE
Add ability to template the base url of AWS API Gateway integration uri

### DIFF
--- a/Swashbuckle.AWSApiGateway.Annotations/XAmazonApiGatewayOperationFilter.cs
+++ b/Swashbuckle.AWSApiGateway.Annotations/XAmazonApiGatewayOperationFilter.cs
@@ -63,12 +63,25 @@ namespace Swashbuckle.AWSApiGateway.Annotations
                             .ToDictionary(key => key.IntegrationRequestParameter, value => value.MethodRequestParameter)
                     );
 
-                return new XAmazonApiGatewayIntegrationOptions
+                if (Uri.IsWellFormedUriString(baseUri, UriKind.RelativeOrAbsolute))
                 {
-                    HttpMethod = ctx.ApiDescription.HttpMethod,
-                    Uri = new Uri(new Uri(baseUri), ctx.ApiDescription.RelativePath).ToString(),
-                    RequestParameters = _options.IntegrationOptions.RequestParameters.Union(requestParameters)
-                };
+                    return new XAmazonApiGatewayIntegrationOptions
+                    {
+                        HttpMethod = ctx.ApiDescription.HttpMethod,
+                        Uri = new Uri(new Uri(baseUri), ctx.ApiDescription.RelativePath).ToString(),
+                        RequestParameters = _options.IntegrationOptions.RequestParameters.Union(requestParameters)
+                    };
+                }
+                else
+                {
+                    var placeholderBaseUrl = "http://www.domain.com";
+                    return new XAmazonApiGatewayIntegrationOptions
+                    {
+                        HttpMethod = ctx.ApiDescription.HttpMethod,
+                        Uri = new Uri(new Uri(placeholderBaseUrl), ctx.ApiDescription.RelativePath).ToString().Replace(placeholderBaseUrl, baseUri),
+                        RequestParameters = _options.IntegrationOptions.RequestParameters.Union(requestParameters)
+                    };
+                }
             }
 
             Apply<XAmazonApiGatewayIntegrationAttribute,XAmazonApiGatewayIntegrationOptions,IXAmazonApiGatewayIntegrationOptions>

--- a/Swashbuckle.AWSApiGateway.Annotations/XAmazonApiGatewayOperationFilter.cs
+++ b/Swashbuckle.AWSApiGateway.Annotations/XAmazonApiGatewayOperationFilter.cs
@@ -63,25 +63,25 @@ namespace Swashbuckle.AWSApiGateway.Annotations
                             .ToDictionary(key => key.IntegrationRequestParameter, value => value.MethodRequestParameter)
                     );
 
+                string uri = string.Empty;
+
                 if (Uri.IsWellFormedUriString(baseUri, UriKind.RelativeOrAbsolute))
                 {
-                    return new XAmazonApiGatewayIntegrationOptions
-                    {
-                        HttpMethod = ctx.ApiDescription.HttpMethod,
-                        Uri = new Uri(new Uri(baseUri), ctx.ApiDescription.RelativePath).ToString(),
-                        RequestParameters = _options.IntegrationOptions.RequestParameters.Union(requestParameters)
-                    };
+                    uri = new Uri(new Uri(baseUri), ctx.ApiDescription.RelativePath).ToString();
                 }
                 else
                 {
                     var placeholderBaseUrl = "http://www.domain.com";
-                    return new XAmazonApiGatewayIntegrationOptions
-                    {
-                        HttpMethod = ctx.ApiDescription.HttpMethod,
-                        Uri = new Uri(new Uri(placeholderBaseUrl), ctx.ApiDescription.RelativePath).ToString().Replace(placeholderBaseUrl, baseUri),
-                        RequestParameters = _options.IntegrationOptions.RequestParameters.Union(requestParameters)
-                    };
+                    uri = new Uri(new Uri(placeholderBaseUrl), ctx.ApiDescription.RelativePath).ToString()
+                        .Replace(placeholderBaseUrl, baseUri);
                 }
+
+                return new XAmazonApiGatewayIntegrationOptions
+                {
+                    HttpMethod = ctx.ApiDescription.HttpMethod,
+                    Uri = uri,
+                    RequestParameters = _options.IntegrationOptions.RequestParameters.Union(requestParameters)
+                };
             }
 
             Apply<XAmazonApiGatewayIntegrationAttribute,XAmazonApiGatewayIntegrationOptions,IXAmazonApiGatewayIntegrationOptions>


### PR DESCRIPTION
Hi Will, what do you think about this change? 

To give more context, I'm working on a 100% automated pipeline that will deploy a .NET Core app in K8S and setup an AWS Api Gateway to point to an ephemeral NLB. 
Since the NLB is created dinamically, the .NET Core app doesn't have knowledge of the final base url so it will need to be templated.

OT. Since it is possible that we are going to need / propose more changes, would it make sense to be added as contributor?

Thanks @waxtell 